### PR TITLE
dev-v0.0.1.20201211.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "radiantkit"
-version = "0.0.1.20201209.1"
+version = "0.0.1.20201211.1"
 description = "Radial Image Analysis Toolkit"
 authors = ["Gabriele Girelli <gigi.ga90@gmail.com>"]
 license = "MIT"

--- a/radiantkit/const.py
+++ b/radiantkit/const.py
@@ -3,7 +3,7 @@
 @contact: gigi.ga90@gmail.com
 """
 
-__version__ = "0.0.1.20201209.1"
+__version__ = "0.0.1.20201211.1"
 
 from enum import Enum
 from typing import Dict, List, Tuple

--- a/radiantkit/image.py
+++ b/radiantkit/image.py
@@ -396,7 +396,6 @@ class ImageBinary(Image):
         if doRebinarize:
             self._rebinarize()
         self._pixels = self._pixels.astype(bool)
-        assert 1 == self.pixels.max()
         self._foreground = self.pixels.sum()
         self._background = np.prod(self.pixels.shape) - self._foreground
 

--- a/radiantkit/series.py
+++ b/radiantkit/series.py
@@ -74,6 +74,9 @@ class Series(ChannelList):
             self.unload(name)
 
     def __run_particle_finder(self, particleClass: Type[Particle] = Particle) -> None:
+        if 0 == self.mask.max():
+            self._particles = []
+            return
         if isinstance(self.mask, ImageLabeled):
             self._particles = ParticleFinder.get_particles_from_labeled_image(
                 self.mask, particleClass

--- a/radiantkit/series.py
+++ b/radiantkit/series.py
@@ -74,7 +74,7 @@ class Series(ChannelList):
             self.unload(name)
 
     def __run_particle_finder(self, particleClass: Type[Particle] = Particle) -> None:
-        if 0 == self.mask.max():
+        if 0 == self.mask.pixels.max():
             self._particles = []
             return
         if isinstance(self.mask, ImageLabeled):

--- a/radiantkit/series.py
+++ b/radiantkit/series.py
@@ -172,23 +172,21 @@ class Series(ChannelList):
         assert channel_name in self.names
         assert all([p.has_distances for p in self._particles])
 
+        particle_details: List[pd.DataFrame] = []
         if self.reference is not None and self.reference != channel_name:
-            df = pd.concat(
-                [
-                    p.get_intensity_at_distance(
-                        self[channel_name][1], self[self.reference][1]
-                    )
-                    for p in self._particles
-                ]
-            )
+            for p in self._particles:
+                tabulated_details = p.get_intensity_at_distance(
+                    self[channel_name][1], self[self.reference][1]
+                )
+                logging.info((type(particle_details)))
+                particle_details.append(tabulated_details)
             self.unload(self.reference)
         else:
-            df = pd.concat(
-                [
-                    p.get_intensity_at_distance(self[channel_name][1])
-                    for p in self._particles
-                ]
-            )
+            for p in self._particles:
+                tabulated_details = p.get_intensity_at_distance(self[channel_name][1])
+                logging.info((type(particle_details)))
+                particle_details.append(tabulated_details)
+        df = pd.concat(particle_details)
         self.unload(channel_name)
 
         df["reference"] = self.reference

--- a/radiantkit/series.py
+++ b/radiantkit/series.py
@@ -169,6 +169,8 @@ class Series(ChannelList):
         return series.init_particles_distances(rdc, reInit)
 
     def get_particles_intensity_at_distance(self, channel_name: str) -> pd.DataFrame:
+        if 0 == len(self._particles):
+            return pd.DataFrame()
         assert channel_name in self.names
         assert all([p.has_distances for p in self._particles])
 

--- a/radiantkit/series.py
+++ b/radiantkit/series.py
@@ -180,13 +180,11 @@ class Series(ChannelList):
                 tabulated_details = p.get_intensity_at_distance(
                     self[channel_name][1], self[self.reference][1]
                 )
-                logging.info((type(particle_details)))
                 particle_details.append(tabulated_details)
             self.unload(self.reference)
         else:
             for p in self._particles:
                 tabulated_details = p.get_intensity_at_distance(self[channel_name][1])
-                logging.info((type(particle_details)))
                 particle_details.append(tabulated_details)
         df = pd.concat(particle_details)
         self.unload(channel_name)

--- a/radiantkit/series.py
+++ b/radiantkit/series.py
@@ -45,7 +45,7 @@ class Series(ChannelList):
     def particles(self) -> List[Nucleus]:
         if 0 == len(self._particles):
             logging.warning(
-                "particle attribute accessible " + "after running extract_particles."
+                "particle attribute accessible after running '.extract_particles()'."
             )
         return self._particles
 
@@ -74,7 +74,7 @@ class Series(ChannelList):
             self.unload(name)
 
     def __run_particle_finder(self, particleClass: Type[Particle] = Particle) -> None:
-        if 0 == self.mask.pixels.max():
+        if self.mask is None or 0 == self.mask.pixels.max():
             self._particles = []
             return
         if isinstance(self.mask, ImageLabeled):


### PR DESCRIPTION
Fixed bug in `select_nuclei` and `radial_population` crashing execution when a series has no nuclei/particles.